### PR TITLE
bump dependencies to match that of activeadmin gem & bump version

### DIFF
--- a/activeadmin_hstore_editor.gemspec
+++ b/activeadmin_hstore_editor.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
 
   spec.required_rubygems_version = ">= 1.3.6"
   spec.add_development_dependency "bundler", "~> 1.5"
-  spec.add_dependency "railties", ">= 3.0", "<= 5.0"
+  spec.add_dependency "railties", ">= 3.0", "< 5.1"
   #spec.add_development_dependency "rake", "~> 0"
   #spec.add_dependency "active_admin", "~> 1.0.0"
 end

--- a/lib/activeadmin/hstore_editor/version.rb
+++ b/lib/activeadmin/hstore_editor/version.rb
@@ -1,5 +1,5 @@
 module ActiveAdmin
   module HstoreEditor
-    VERSION = "0.0.6"
+    VERSION = "0.0.7"
   end
 end


### PR DESCRIPTION
Part of rails - actionview 5.0.0 gem has vulnerability. The solution is to update it to 5.0.0.1, but the dependency blocks it. What's more, activeadmin gem has < 5.1 dependency. I suggest merging to update the dependency.